### PR TITLE
ADD sphinx documentation

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,14 @@
+# Documentation
+
+Documentation is built with sphinx.
+
+Build the documentation (it must be executed in the `docs` folder):
+```
+sphinx-build . _build
+```
+
+### Doc coverage
+it is possible to check the class coverage to find classes that are missing from the documentation using the command:
+```
+sphinx-build -b coverage . _build
+```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,44 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('..'))
+
+import fedray
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+project = 'fedray'
+copyright = '2022, Valerio De Caro'
+author = 'Valerio De Caro'
+release = '0.0.1'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.napoleon",
+    "sphinx_copybutton",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.coverage",
+    "sphinx.ext.napoleon",
+    "sphinx_rtd_theme"
+]
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+coverage_show_missing_items = True
+autosummary_generate = True
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']

--- a/docs/example.rst
+++ b/docs/example.rst
@@ -1,0 +1,4 @@
+Welcome to an example tutorial
+==================================
+
+blahblah blahblah.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,43 @@
+.. fedray documentation master file, created by
+   sphinx-quickstart on Tue Dec  6 17:22:18 2022.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to fedray's documentation!
+==================================
+
+..  toctree::
+   :maxdepth: 1
+   :caption: fedray tutorials
+
+   Example Tutorial <example>
+
+
+.. currentmodule:: fedray
+
+.. autosummary::
+    :toctree: generated
+
+   remote
+
+
+fedray.process
+==================================
+
+.. currentmodule:: fedray.process
+
+.. autosummary::
+    :toctree: generated
+
+   ClientServerProcess
+   DecentralizedProcess
+   FederatedProcess
+   HierarchicalProcess
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx
+sphinx-copybutton

--- a/fedray/core/_private/message.py
+++ b/fedray/core/_private/message.py
@@ -1,7 +1,12 @@
 from dataclasses import field, dataclass
 import datetime
 
-from typing import Dict, Literal
+from typing import Dict
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
+
 
 @dataclass
 class Message:


### PR DESCRIPTION
- added sphinx documentation
- based on avalanche apidoc, with [napoleon](https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html) plugin to support numpy and googlestyle docstrings
- added a requirements.txt with dependencies needed to build the doc and a README with instructions.

# Preview:
![immagine](https://user-images.githubusercontent.com/8118624/207274934-a512a567-615b-4380-9d98-7916f944425d.png)
